### PR TITLE
Add the "pull" command

### DIFF
--- a/lib/rosette/client.rb
+++ b/lib/rosette/client.rb
@@ -5,9 +5,12 @@ require 'rosette/client/repo'
 
 module Rosette
   module Client
-    autoload :Api,         'rosette/client/api'
-    autoload :Terminal,    'rosette/client/terminal'
-    autoload :Commands,    'rosette/client/commands'
-    autoload :Response,    'rosette/client/response'
+    autoload :Api,           'rosette/client/api'
+    autoload :Terminal,      'rosette/client/terminal'
+    autoload :Writer,        'rosette/client/writer'
+    autoload :Commands,      'rosette/client/commands'
+    autoload :Response,      'rosette/client/response'
+    autoload :HashResponse,  'rosette/client/response'
+    autoload :ArrayResponse, 'rosette/client/response'
   end
 end

--- a/lib/rosette/client/api.rb
+++ b/lib/rosette/client/api.rb
@@ -16,6 +16,13 @@ module Rosette
 
       attr_reader :host, :port, :version
 
+      def self.url_join(*args)
+        args
+          .map { |arg| arg.gsub(/\A\/(.*)\/\z/, '\1') }  # remove slashes
+          .reject { |arg| arg.empty? }                   # get rid of empties
+          .join('/')
+      end
+
       def initialize(options = {})
         @host = options.fetch(:host, DEFAULT_HOST)
         @port = options.fetch(:port, DEFAULT_PORT)
@@ -96,11 +103,15 @@ module Rosette
       end
 
       def make_get_url(path, params)
-        File.join(base_url, path, "?#{make_param_string(params)}")
+        url_join(base_url, path, "?#{make_param_string(params)}")
       end
 
       def make_post_url(path, params)
-        File.join(base_url, path)
+        url_join(base_url, path)
+      end
+
+      def url_join(*args)
+        self.class.url_join(*args)
       end
 
       def post(url, params)

--- a/lib/rosette/client/api.rb
+++ b/lib/rosette/client/api.rb
@@ -54,6 +54,10 @@ module Rosette
         wrap(make_request(:get, 'translations/export.json', params))
       end
 
+      def locales(params)
+        wrap(make_request(:get, 'locales.json', params))
+      end
+
       private
 
       def wrap(api_response)

--- a/lib/rosette/client/cli.rb
+++ b/lib/rosette/client/cli.rb
@@ -6,17 +6,18 @@ module Rosette
   module Client
 
     class Cli
-      attr_reader :api, :terminal, :repo
+      attr_reader :api, :terminal, :writer, :repo
 
-      def initialize(terminal, api, repo)
+      def initialize(terminal, writer, api, repo)
         @api = api
         @terminal = terminal
+        @writer = writer
         @repo = repo
       end
 
       def start(argv)
         if command_const = find_command_const(argv.first)
-          command_const.new(api, terminal, repo, argv[1..-1]).execute
+          command_const.new(api, terminal, writer, repo, argv[1..-1]).execute
         else
           terminal.say("Command '#{argv.first}' not recognized.")
         end

--- a/lib/rosette/client/commands.rb
+++ b/lib/rosette/client/commands.rb
@@ -16,17 +16,26 @@ module Rosette
       autoload :SnapshotCommandArgs,     'rosette/client/commands/snapshot_command'
       autoload :RepoSnapshotCommand,     'rosette/client/commands/repo_snapshot_command'
       autoload :RepoSnapshotCommandArgs, 'rosette/client/commands/repo_snapshot_command'
+      autoload :PullCommand,             'rosette/client/commands/pull_command'
+      autoload :PullCommandArgs,         'rosette/client/commands/pull_command'
 
       class Command
-        attr_reader :api, :terminal, :repo
+        attr_reader :api, :terminal, :writer, :repo, :args
 
-        def initialize(api, terminal, repo)
+        def initialize(api, terminal, writer, repo, argv)
           @api = api
           @terminal = terminal
+          @writer = writer
           @repo = repo
+          @args = parse_args(argv)
         end
 
         protected
+
+        def parse_args(args)
+          raise NotImplementedError,
+            "#{__method__} must be defined in derived classes"
+        end
 
         def print_hash(hash)
           hash.each_pair do |key, value|

--- a/lib/rosette/client/commands/commit_command.rb
+++ b/lib/rosette/client/commands/commit_command.rb
@@ -13,13 +13,6 @@ module Rosette
       end
 
       class CommitCommand < Command
-        attr_reader :args
-
-        def initialize(api, terminal, repo, argv)
-          super(api, terminal, repo)
-          @args = CommitCommandArgs.from_argv(argv, repo)
-        end
-
         def execute
           terminal.say("Committing phrases for '#{args.ref}'...")
 
@@ -34,6 +27,12 @@ module Rosette
             terminal.say("Modified: #{response.modified || 0}")
             terminal.say('done.')
           end
+        end
+
+        private
+
+        def parse_args(args)
+          CommitCommandArgs.from_argv(args, repo)
         end
       end
 

--- a/lib/rosette/client/commands/diff_command.rb
+++ b/lib/rosette/client/commands/diff_command.rb
@@ -41,13 +41,6 @@ module Rosette
       end
 
       class DiffCommand < Command
-        attr_reader :args
-
-        def initialize(api, terminal, repo, argv)
-          super(api, terminal, repo)
-          @args = DiffCommandArgs.from_argv(argv, repo)
-        end
-
         def execute
           response = api.diff(
             repo_name: derive_repo_name,
@@ -62,6 +55,10 @@ module Rosette
         end
 
         private
+
+        def parse_args(args)
+          DiffCommandArgs.from_argv(args, repo)
+        end
 
         def add_str_for(change)
           str = "#{change['key']}"

--- a/lib/rosette/client/commands/pull_command.rb
+++ b/lib/rosette/client/commands/pull_command.rb
@@ -1,0 +1,115 @@
+# encoding: UTF-8
+
+# git rs pull [ref] -f file_pattern -s serializer
+
+require 'base64'
+require 'optparse'
+
+module Rosette
+  module Client
+    module Commands
+
+      PullCommandArgs = Struct.new(:ref, :file_pattern, :serializer) do
+        def self.from_argv(argv, repo, terminal)
+          options = {}
+
+          parser = OptionParser.new do |opts|
+            desc = "File pattern to use. Can contain these placeholders:\n" +
+              "* %{locale.code}: The full locale code, eg. pt-BR\n" +
+              "* %{locale.territory}: The locale's territory part, eg. 'BR'" +
+              "* %{locale.language}: The locale's language part, eg. 'pt'"
+
+            opts.on('-f pattern', '--file-pattern pattern', desc) do |pattern|
+              pattern.strip!
+              options[:file_pattern] = pattern.empty? ? nil : pattern
+            end
+
+            desc = 'The serializer to use. Translations will be requested in ' +
+              'this format.'
+
+            opts.on('-s serializer', '--serializer serializer', desc) do |serializer|
+              serializer.strip!
+              options[:serializer] = serializer.empty? ? nil : serializer
+            end
+          end
+
+          parser.parse(argv[1..-1])
+          options[:ref] = repo.rev_parse(argv[0] || repo.get_head)
+          validate_options!(options, terminal)
+
+          new(
+            options[:ref],
+            options[:file_pattern],
+            options[:serializer]
+          )
+        end
+
+        def self.validate_options!(options, terminal)
+          unless options.include?(:file_pattern)
+            terminal.say('Please supply a file pattern via the -f option')
+            exit 1
+          end
+
+          unless options.include?(:serializer)
+            terminal.say('Please supply a serializer via the -s option')
+            exit 1
+          end
+        end
+      end
+
+      # a show is really just a diff against your parent (so the inheritance makes sense)
+      class PullCommand < Command
+        def execute
+          locales = api.locales(
+            repo_name: derive_repo_name
+          )
+
+          handle_error(locales) do |locales|
+            export_locales(locales)
+          end
+        end
+
+        private
+
+        def parse_args(args)
+          PullCommandArgs.from_argv(args, repo, terminal)
+        end
+
+        def export_locales(locales)
+          locales.each do |locale|
+            export_locale(locale)
+          end
+        end
+
+        def export_locale(locale)
+          response = api.export({
+            repo_name: derive_repo_name,
+            ref: args.ref,
+            locale: locale['code'],
+            serializer: args.serializer,
+            base_64_encode: true
+          })
+
+          handle_error(response) do |response|
+            payload = Base64.decode64(response.payload)
+            path = path_for(locale)
+            terminal.say("Writing #{path}")
+
+            writer.open(path, 'w+') do |f|
+              f.write(payload)
+            end
+          end
+        end
+
+        def path_for(locale)
+          args.file_pattern % {
+            :'locale.code' => locale['code'],
+            :'locale.territory' => locale['territory'],
+            :'locale.language' => locale['language']
+          }
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rosette/client/commands/repo_snapshot_command.rb
+++ b/lib/rosette/client/commands/repo_snapshot_command.rb
@@ -14,13 +14,6 @@ module Rosette
 
       # a show is really just a diff against your parent (so the inheritance makes sense)
       class RepoSnapshotCommand < Command
-        attr_reader :args
-
-        def initialize(api, terminal, repo, argv)
-          super(api, terminal, repo)
-          @args = RepoSnapshotCommandArgs.from_argv(argv, repo)
-        end
-
         def execute
           response = api.repo_snapshot(
             repo_name: derive_repo_name,
@@ -30,6 +23,12 @@ module Rosette
           handle_error(response) do |response|
             print_hash(response.attributes)
           end
+        end
+
+        private
+
+        def parse_args(args)
+          RepoSnapshotCommandArgs.from_argv(args, repo)
         end
       end
 

--- a/lib/rosette/client/commands/show_command.rb
+++ b/lib/rosette/client/commands/show_command.rb
@@ -14,15 +14,6 @@ module Rosette
 
       # a show is really just a diff against your parent (so the inheritance makes sense)
       class ShowCommand < DiffCommand
-        attr_reader :args
-
-        def initialize(api, terminal, repo, argv)
-          @api = api
-          @terminal = terminal
-          @repo = repo
-          @args = ShowCommandArgs.from_argv(argv, repo)
-        end
-
         def execute
           response = api.show(
             repo_name: derive_repo_name,
@@ -32,6 +23,12 @@ module Rosette
           handle_error(response) do |response|
             print_diff(response.attributes)
           end
+        end
+
+        private
+
+        def parse_args(args)
+          ShowCommandArgs.from_argv(args, repo)
         end
       end
 

--- a/lib/rosette/client/commands/snapshot_command.rb
+++ b/lib/rosette/client/commands/snapshot_command.rb
@@ -14,13 +14,6 @@ module Rosette
 
       # a show is really just a diff against your parent (so the inheritance makes sense)
       class SnapshotCommand < Command
-        attr_reader :args
-
-        def initialize(api, terminal, repo, argv)
-          super(api, terminal, repo)
-          @args = SnapshotCommandArgs.from_argv(argv, repo)
-        end
-
         def execute
           response = api.snapshot(
             repo_name: derive_repo_name,
@@ -33,6 +26,10 @@ module Rosette
               terminal.say('')
             end
           end
+        end
+
+        def parse_args(args)
+          SnapshotCommandArgs.from_argv(args, repo)
         end
       end
 

--- a/lib/rosette/client/commands/status_command.rb
+++ b/lib/rosette/client/commands/status_command.rb
@@ -14,15 +14,6 @@ module Rosette
 
       # a show is really just a diff against your parent (so the inheritance makes sense)
       class StatusCommand < Command
-        attr_reader :args
-
-        def initialize(api, terminal, repo, argv)
-          @api = api
-          @terminal = terminal
-          @repo = repo
-          @args = StatusCommandArgs.from_argv(argv, repo)
-        end
-
         def execute
           response = api.status(
             repo_name: derive_repo_name,
@@ -39,6 +30,10 @@ module Rosette
         end
 
         private
+
+        def parse_args(args)
+          StatusCommandArgs.from_argv(args, repo)
+        end
 
         HEADER = ['Locale', 'Phrases', 'Translations', 'Percent']
 

--- a/lib/rosette/client/response.rb
+++ b/lib/rosette/client/response.rb
@@ -4,11 +4,18 @@ module Rosette
   module Client
 
     class Response
-      attr_reader :attributes
-
-      def self.from_api_response(hash)
-        new(hash)
+      def self.from_api_response(hash_or_array)
+        case hash_or_array
+          when Hash
+            HashResponse.new(hash_or_array)
+          else
+            ArrayResponse.new(hash_or_array)
+        end
       end
+    end
+
+    class HashResponse
+      attr_reader :attributes
 
       def initialize(hash)
         @attributes = hash
@@ -31,6 +38,24 @@ module Rosette
       # responds to everything, returns nil for any unset attributes
       def respond_to?(method)
         true
+      end
+    end
+
+    class ArrayResponse < Array
+      def initialize(array)
+        replace(array)
+      end
+
+      def error?
+        false
+      end
+
+      def success?
+        true
+      end
+
+      def attributes
+        self
       end
     end
 

--- a/lib/rosette/client/writer.rb
+++ b/lib/rosette/client/writer.rb
@@ -1,0 +1,15 @@
+# encoding: UTF-8
+
+require 'yaml'
+
+module Rosette
+  module Client
+
+    class Writer
+      def self.open(path, mode, &block)
+        File.open(path, mode, &block)
+      end
+    end
+
+  end
+end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -30,13 +30,13 @@ describe Api do
     let(:response_type) { HashResponse }
 
     before(:each) do
-      url = File.join('http://localhost:8080/v1', path)
+      url = Api.url_join('http://localhost:8080/v1', path)
 
       args = case verb
         when :get
-          [File.join(url, "#{endpoint_override rescue endpoint}.json/?param=value")]
+          [Api.url_join(url, "#{endpoint_override rescue endpoint}.json", '?param=value')]
         else
-          [File.join(url, "#{endpoint_override rescue endpoint}.json"), params]
+          [Api.url_join(url, "#{endpoint_override rescue endpoint}.json"), params]
       end
 
       allow(api).to receive(verb).with(*args).and_return('{"foo":"bar"}')

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -27,27 +27,35 @@ describe Api do
     let(:api) { api_class.new }
     let(:params) { { param: 'value' } }
     let(:endpoint) { method }
+    let(:response_type) { HashResponse }
 
     before(:each) do
-      url = "http://localhost:8080/v1/#{path}"
+      url = File.join('http://localhost:8080/v1', path)
 
       args = case verb
         when :get
-          ["#{url}/#{endpoint_override rescue endpoint}.json/?param=value"]
+          [File.join(url, "#{endpoint_override rescue endpoint}.json/?param=value")]
         else
-          ["#{url}/#{endpoint_override rescue endpoint}.json", params]
+          [File.join(url, "#{endpoint_override rescue endpoint}.json"), params]
       end
 
       allow(api).to receive(verb).with(*args).and_return('{"foo":"bar"}')
     end
 
     it 'wraps the response in a Response object' do
-      expect(api.send(endpoint, params)).to be_a(Response)
+      expect(api.send(endpoint, params)).to be_a(response_type)
     end
   end
 
   context 'get requests' do
     let(:verb) { :get }
+
+    describe '#locales' do
+      let(:path) { '' }
+      let(:method) { :locales }
+      let(:response_type) { ArrayResponse }
+      it_behaves_like 'an api endpoint'
+    end
 
     describe '#diff' do
       let(:path) { 'git' }

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,7 +9,8 @@ describe Cli do
   let(:base_repo) { TmpRepo.new }
   let(:repo) { Repo.new(base_repo.working_dir) }
   let(:terminal) { FakeTerminal.new }
-  let(:cli) { Cli.new(terminal, api, repo) }
+  let(:writer) { FakeWriter.new }
+  let(:cli) { Cli.new(terminal, writer, api, repo) }
 
   before(:each) do
     add_user_to(base_repo)
@@ -21,7 +22,7 @@ describe Cli do
       base_repo.add_all
       base_repo.commit('Initial commit')
 
-      expect(api).to receive(:commit).and_return(Response.new({ 'foo' => 'bar' }))
+      expect(api).to receive(:commit).and_return(Response.from_api_response({ 'foo' => 'bar' }))
       cli.start(['commit', base_repo.git('rev-parse HEAD').strip])
     end
 

--- a/spec/commands/commit_command_spec.rb
+++ b/spec/commands/commit_command_spec.rb
@@ -10,9 +10,10 @@ describe CommitCommand do
   let(:base_repo) { TmpRepo.new }
   let(:repo) { Repo.new(base_repo.working_dir) }
   let(:terminal) { FakeTerminal.new }
+  let(:writer) { FakeWriter.new }
   let(:repo_name) { 'my_awesome_repo' }
   let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
-  let(:command) { CommitCommand.new(api, terminal, repo, [commit_id]) }
+  let(:command) { CommitCommand.new(api, terminal, writer, repo, [commit_id]) }
 
   before(:each) do
     add_user_to(base_repo)
@@ -32,7 +33,7 @@ describe CommitCommand do
     it 'makes a commit api call' do
       expect(api).to receive(:commit)
         .with(repo_name: repo_name, ref: commit_id)
-        .and_return(Response.new({}))
+        .and_return(Response.from_api_response({}))
 
       command.execute
     end
@@ -41,7 +42,7 @@ describe CommitCommand do
       expect(api).to receive(:commit)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new(
+          Response.from_api_response(
             { 'added' => 1, 'removed' => 2, 'modified' => 3 }
           )
         )
@@ -57,7 +58,9 @@ describe CommitCommand do
       expect(api).to receive(:commit)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({ 'error' => 'Jelly beans', 'added' => 1 })
+          Response.from_api_response(
+            'error' => 'Jelly beans', 'added' => 1
+          )
         )
 
       command.execute

--- a/spec/commands/diff_command_spec.rb
+++ b/spec/commands/diff_command_spec.rb
@@ -84,8 +84,15 @@ describe 'diff' do
 
   describe DiffCommand do
     let(:api) { double }
-    let(:command) { DiffCommand.new(api, terminal, repo, [master_commit_id, new_branch_commit_id]) }
+    let(:command) do
+      DiffCommand.new(
+        api, terminal, writer, repo,
+        [master_commit_id, new_branch_commit_id]
+      )
+    end
+
     let(:terminal) { FakeTerminal.new }
+    let(:writer) { FakeWriter.new }
 
     describe '#execute' do
       it 'makes a diff api call' do
@@ -96,7 +103,7 @@ describe 'diff' do
             diff_point_ref: master_commit_id,
             paths: ''
           )
-          .and_return(Response.new({}))
+          .and_return(Response.from_api_response({}))
 
         command.execute
       end
@@ -110,7 +117,7 @@ describe 'diff' do
             paths: ''
           )
           .and_return(
-            Response.new(
+            Response.from_api_response(
               sample_diff(new_branch_commit_id)
             )
           )
@@ -136,7 +143,7 @@ describe 'diff' do
             paths: ''
           )
           .and_return(
-            Response.new({ 'error' => 'Jelly beans' }.merge(
+            Response.from_api_response({ 'error' => 'Jelly beans' }.merge(
               sample_diff(new_branch_commit_id))
             )
           )

--- a/spec/commands/pull_command_args_spec.rb
+++ b/spec/commands/pull_command_args_spec.rb
@@ -1,0 +1,48 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+include Rosette::Client
+include Rosette::Client::Commands
+
+describe PullCommandArgs do
+  let(:base_repo) { TmpRepo.new }
+  let(:repo) { Repo.new(base_repo.working_dir) }
+  let(:terminal) { FakeTerminal.new }
+  let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
+  let(:repo_name) { 'my_awesome_repo' }
+
+  before(:each) do
+    add_user_to(base_repo)
+    base_repo.git("remote add origin git@github.com/camertron/#{repo_name}")
+    base_repo.create_file('file.txt') { |f| f.write('hello, world') }
+    base_repo.add_all
+    base_repo.commit('Initial commit')
+  end
+
+  describe 'from_argv' do
+    it 'exits and prints message when not given a file pattern' do
+      expect do
+        PullCommandArgs.from_argv(
+          [commit_id, '--serializer', 'foo/bar'], repo, terminal
+        )
+      end.to raise_error(SystemExit)
+
+      expect(terminal).to have_said(
+        'Please supply a file pattern via the -f option'
+      )
+    end
+
+    it 'exits and prints message when not given a serializer' do
+      expect do
+        PullCommandArgs.from_argv(
+          [commit_id, '--file-pattern', 'teapot'], repo, terminal
+        )
+      end.to raise_error(SystemExit)
+
+      expect(terminal).to have_said(
+        'Please supply a serializer via the -s option'
+      )
+    end
+  end
+end

--- a/spec/commands/pull_command_spec.rb
+++ b/spec/commands/pull_command_spec.rb
@@ -1,0 +1,121 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'base64'
+
+include Rosette::Client
+include Rosette::Client::Commands
+
+describe PullCommand do
+  let(:api) { double }
+  let(:base_repo) { TmpRepo.new }
+  let(:repo) { Repo.new(base_repo.working_dir) }
+  let(:terminal) { FakeTerminal.new }
+  let(:writer) { FakeWriter.new }
+  let(:repo_name) { 'my_awesome_repo' }
+  let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
+  let(:serializer) { 'yaml/rails' }
+  let(:file_pattern) { 'config/locales/%{locale.code}.yml' }
+  let(:command) do
+    PullCommand.new(
+      api, terminal, writer, repo, [
+        commit_id, "-f #{file_pattern}", "-s #{serializer}"
+      ]
+    )
+  end
+
+  let(:locales) do
+    [
+      {
+        'code' => 'ja-JP',
+        'language' => 'ja',
+        'territory' => 'JP'
+      }, {
+        'code' => 'pt-BR',
+        'language' => 'pt',
+        'territory' => 'BR'
+      }
+    ]
+  end
+
+  let(:params) do
+    {
+      repo_name: repo_name,
+      ref: commit_id,
+      serializer: serializer,
+      base_64_encode: true
+    }
+  end
+
+  before(:each) do
+    add_user_to(base_repo)
+    base_repo.git("remote add origin git@github.com/camertron/#{repo_name}")
+    base_repo.create_file('file.txt') { |f| f.write('hello, world') }
+    base_repo.add_all
+    base_repo.commit('Initial commit')
+  end
+
+  around(:each) do |example|
+    Dir.chdir(base_repo.working_dir) do
+      example.run
+    end
+  end
+
+  context 'with a mocked list of locales' do
+    before(:each) do
+      expect(api).to receive(:locales)
+        .with(repo_name: repo_name)
+        .and_return(Response.from_api_response(locales))
+
+      locales.each do |locale|
+        expect(api).to receive(:export)
+          .with(params.merge(locale: locale['code']))
+          .and_return(
+            Response.from_api_response({
+              'payload' => Base64.encode64("payload for #{locale['code']}")
+            })
+          )
+      end
+    end
+
+    describe '#execute' do
+      it 'exports translations for each locale' do
+        command.execute
+
+        locales.each do |locale|
+          file = file_pattern % { :'locale.code' => locale['code'] }
+          expect(writer).to have_written_content_for(file)
+          expect(writer.contents_of(file)).to eq("payload for #{locale['code']}")
+        end
+      end
+
+      context 'with a territory-based file pattern' do
+        let(:file_pattern) { 'config/locales/%{locale.territory}.yml' }
+
+        it 'exports translations for each locale' do
+          command.execute
+
+          locales.each do |locale|
+            file = file_pattern % { :'locale.territory' => locale['territory'] }
+            expect(writer).to have_written_content_for(file)
+            expect(writer.contents_of(file)).to eq("payload for #{locale['code']}")
+          end
+        end
+      end
+
+      context 'with a language-based file pattern' do
+        let(:file_pattern) { 'config/locales/%{locale.language}.yml' }
+
+        it 'exports translations for each locale' do
+          command.execute
+
+          locales.each do |locale|
+            file = file_pattern % { :'locale.language' => locale['language'] }
+            expect(writer).to have_written_content_for(file)
+            expect(writer.contents_of(file)).to eq("payload for #{locale['code']}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/repo_snapshot_command_spec.rb
+++ b/spec/commands/repo_snapshot_command_spec.rb
@@ -10,9 +10,14 @@ describe RepoSnapshotCommand do
   let(:base_repo) { TmpRepo.new }
   let(:repo) { Repo.new(base_repo.working_dir) }
   let(:terminal) { FakeTerminal.new }
+  let(:writer) { FakeWriter.new }
   let(:repo_name) { 'my_awesome_repo' }
   let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
-  let(:command) { RepoSnapshotCommand.new(api, terminal, repo, [commit_id]) }
+  let(:command) do
+    RepoSnapshotCommand.new(
+      api, terminal, writer, repo, [commit_id]
+    )
+  end
 
   before(:each) do
     add_user_to(base_repo)
@@ -32,7 +37,7 @@ describe RepoSnapshotCommand do
     it 'makes a repo_snapshot api call' do
       expect(api).to receive(:repo_snapshot)
         .with(repo_name: repo_name, ref: commit_id)
-        .and_return(Response.new({}))
+        .and_return(Response.from_api_response({}))
 
       command.execute
     end
@@ -41,7 +46,7 @@ describe RepoSnapshotCommand do
       expect(api).to receive(:repo_snapshot)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({
+          Response.from_api_response({
             'file1.txt' => 'abc123',
             'path/file2.txt' => 'def456',
             'my/awesome/file3.rb' => 'ghi789'
@@ -59,7 +64,7 @@ describe RepoSnapshotCommand do
       expect(api).to receive(:repo_snapshot)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({ 'error' => 'Jelly beans', 'file1.txt' => 'abc123' })
+          Response.from_api_response({ 'error' => 'Jelly beans', 'file1.txt' => 'abc123' })
         )
 
       command.execute

--- a/spec/commands/show_command_spec.rb
+++ b/spec/commands/show_command_spec.rb
@@ -10,9 +10,10 @@ describe ShowCommand do
   let(:base_repo) { TmpRepo.new }
   let(:repo) { Repo.new(base_repo.working_dir) }
   let(:terminal) { FakeTerminal.new }
+  let(:writer) { FakeWriter.new }
   let(:repo_name) { 'my_awesome_repo' }
   let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
-  let(:command) { ShowCommand.new(api, terminal, repo, [commit_id]) }
+  let(:command) { ShowCommand.new(api, terminal, writer, repo, [commit_id]) }
 
   before(:each) do
     add_user_to(base_repo)
@@ -32,7 +33,7 @@ describe ShowCommand do
     it 'makes a commit api call' do
       expect(api).to receive(:show)
         .with(repo_name: repo_name, ref: commit_id)
-        .and_return(Response.new({}))
+        .and_return(Response.from_api_response({}))
 
       command.execute
     end
@@ -41,7 +42,7 @@ describe ShowCommand do
       expect(api).to receive(:show)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new(sample_diff(commit_id))
+          Response.from_api_response(sample_diff(commit_id))
         )
 
       command.execute
@@ -60,7 +61,9 @@ describe ShowCommand do
       expect(api).to receive(:show)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({ 'error' => 'Jelly beans' }.merge(sample_diff(commit_id)))
+          Response.from_api_response(
+            { 'error' => 'Jelly beans' }.merge(sample_diff(commit_id))
+          )
         )
 
       command.execute

--- a/spec/commands/snapshot_command_spec.rb
+++ b/spec/commands/snapshot_command_spec.rb
@@ -10,9 +10,10 @@ describe SnapshotCommand do
   let(:base_repo) { TmpRepo.new }
   let(:repo) { Repo.new(base_repo.working_dir) }
   let(:terminal) { FakeTerminal.new }
+  let(:writer) { FakeWriter.new }
   let(:repo_name) { 'my_awesome_repo' }
   let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
-  let(:command) { SnapshotCommand.new(api, terminal, repo, [commit_id]) }
+  let(:command) { SnapshotCommand.new(api, terminal, writer, repo, [commit_id]) }
 
   before(:each) do
     add_user_to(base_repo)
@@ -32,7 +33,7 @@ describe SnapshotCommand do
     it 'makes a snapshot api call' do
       expect(api).to receive(:snapshot)
         .with(repo_name: repo_name, ref: commit_id)
-        .and_return(Response.new({}))
+        .and_return(Response.from_api_response({}))
 
       command.execute
     end
@@ -41,7 +42,7 @@ describe SnapshotCommand do
       expect(api).to receive(:snapshot)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new([
+          Response.from_api_response([
             { 'key' => 'Foo', 'commit_id' => 'abc123' },
             { 'key' => 'Bar', 'commit_id' => 'def456' },
             { 'key' => 'Baz', 'commit_id' => 'ghi789' }
@@ -62,7 +63,7 @@ describe SnapshotCommand do
       expect(api).to receive(:snapshot)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({ 'error' => 'Jelly beans' })
+          Response.from_api_response({ 'error' => 'Jelly beans' })
         )
 
       command.execute

--- a/spec/commands/status_command_spec.rb
+++ b/spec/commands/status_command_spec.rb
@@ -10,9 +10,10 @@ describe StatusCommand do
   let(:base_repo) { TmpRepo.new }
   let(:repo) { Repo.new(base_repo.working_dir) }
   let(:terminal) { FakeTerminal.new }
+  let(:writer) { FakeWriter.new }
   let(:repo_name) { 'my_awesome_repo' }
   let(:commit_id) { base_repo.git('rev-parse HEAD').strip }
-  let(:command) { StatusCommand.new(api, terminal, repo, [commit_id]) }
+  let(:command) { StatusCommand.new(api, terminal, writer, repo, [commit_id]) }
 
   before(:each) do
     add_user_to(base_repo)
@@ -32,7 +33,7 @@ describe StatusCommand do
     it 'makes a commit api call' do
       expect(api).to receive(:status)
         .with(repo_name: repo_name, ref: commit_id)
-        .and_return(Response.new({}))
+        .and_return(Response.from_api_response({}))
 
       command.execute
     end
@@ -41,7 +42,7 @@ describe StatusCommand do
       expect(api).to receive(:status)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({
+          Response.from_api_response({
             'commit_id' => commit_id,
             'status' => 'UNTRANSLATED',
             'phrase_count' => 10,
@@ -67,7 +68,7 @@ describe StatusCommand do
       expect(api).to receive(:status)
         .with(repo_name: repo_name, ref: commit_id)
         .and_return(
-          Response.new({ 'error' => 'Jelly beans' })
+          Response.from_api_response({ 'error' => 'Jelly beans' })
         )
 
       command.execute

--- a/spec/helpers/fake_writer.rb
+++ b/spec/helpers/fake_writer.rb
@@ -1,0 +1,22 @@
+# encoding: UTF-8
+
+class FakeWriter
+  attr_reader :streams
+
+  def initialize
+    @streams = {}
+  end
+
+  def open(file, mode)
+    streams[file] ||= StringIO.new
+    yield streams[file]
+  end
+
+  def contents_of(file)
+    streams[file].string
+  end
+
+  def has_written_content_for?(file)
+    streams.include?(file)
+  end
+end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -5,7 +5,34 @@ require 'spec_helper'
 include Rosette::Client
 
 describe Response do
-  let(:response_class) { Response }
+  describe 'from_api_response' do
+    it 'accepts a hash of attributes and returns an instance of HashResponse' do
+      response = Response.from_api_response({ 'foo' => 'bar' })
+      expect(response).to be_a(HashResponse)
+      expect(response.attributes).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'accepts an array and returns an instance of ArrayResponse' do
+      response = Response.from_api_response(['foo', 'bar'])
+      expect(response).to be_a(ArrayResponse)
+      expect(response.attributes).to eq(['foo', 'bar'])
+    end
+  end
+end
+
+describe ArrayResponse do
+  let(:response_class) { ArrayResponse }
+
+  describe '#attributes' do
+    it 'returns itself' do
+      response = response_class.new(['foo', 'bar'])
+      expect(response.attributes).to eq(['foo', 'bar'])
+    end
+  end
+end
+
+describe HashResponse do
+  let(:response_class) { HashResponse }
 
   it 'responds to methods that are also keys in the attributes hash' do
     response = response_class.new({ 'hello' => 'world' })
@@ -15,14 +42,6 @@ describe Response do
   it "returns nil if the method isn't part of the attributes hash" do
     response = response_class.new({ 'hello' => 'world' })
     expect(response.nothing).to be_nil
-  end
-
-  describe 'from_api_response' do
-    it 'accepts a hash of attributes and returns an instance of Response' do
-      response = response_class.from_api_response({ 'foo' => 'bar' })
-      expect(response).to be_a(response_class)
-      expect(response.attributes).to eq({ 'foo' => 'bar' })
-    end
   end
 
   describe '#error?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'pry-nav'
 require 'rspec'
 require 'rosette/client'
 require 'helpers/fake_terminal'
+require 'helpers/fake_writer'
 require 'tmp-repo'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Enables running commands like

`git rosette pull [ref] --file-pattern "config/locales/%{locale.language}.yml" --serializer yaml/rails`

to pull and write translation files. Makes use of the export endpoint.

@jdoconnor @11mdlow 
